### PR TITLE
fix: include cmath so we can use sqrt and pow

### DIFF
--- a/decide/decide.hpp
+++ b/decide/decide.hpp
@@ -2,6 +2,7 @@
 #define DECIDE_H
 
 #include <vector>
+#include <cmath>
 
 // Type declarations
 //


### PR DESCRIPTION
Resolves #35

The decide.hpp file uses these math functions to calculate the distance between two points. The include makes it so we can compile without error.