### PR TITLE
feat: Add equality operators to Coordinate struct

### DIFF
--- a/decide/decide.hpp
+++ b/decide/decide.hpp
@@ -6,29 +6,24 @@
 
 // Type declarations
 //
-typedef enum { ANDD,
-               ORR,
-               NOTUSED } Connector;
+typedef enum { ANDD, ORR, NOTUSED } Connector;
 
 struct Coordinate {
-    double x;
-    double y;
+  double x;
+  double y;
 
-    Coordinate(double x, double y) : x(x), y(y) {
-    }
+  Coordinate(double x, double y) : x(x), y(y) {}
 
-    // Get distance from this coordinate to `other` coordinate.
-    double distance(const Coordinate& other) const {
-        return sqrt(pow(this->x - other.x, 2) + pow(this->y - other.y, 2));
-    }
+  // Get distance from this coordinate to `other` coordinate.
+  double distance(const Coordinate &other) const {
+    return sqrt(pow(this->x - other.x, 2) + pow(this->y - other.y, 2));
+  }
 
-    // Pointers are only used because `this` defaults to a pointer.
-    bool operator==(const Coordinate& c2){
-        return this->x == c2.x && this->y == c2.y;
-    }
-    bool operator!= (const Coordinate& c2){
-        return !(*this == c2);
-    }
+  // Pointers are only used because `this` defaults to a pointer.
+  bool operator==(const Coordinate &c2) {
+    return this->x == c2.x && this->y == c2.y;
+  }
+  bool operator!=(const Coordinate &c2) { return !(*this == c2); }
 };
 
 /* Taken from the header file provided. Redesign as necessary.
@@ -36,25 +31,25 @@ struct Coordinate {
  * declare it as `void DECIDE(void)`, so what they mean by "parameters" is most
  * likely "the data used to decide", not "function arguments". */
 typedef struct {
-    double LENGTH1;  // LengthinLICs0,7,12
-    double RADIUS1;  // RadiusinLICs1,8,13
-    double EPSILON;  // DeviationfromPIinLICs2,9
-    double AREA1;    // AreainLICs3,10,14
-    int QPTS;        // No.ofconsecutivepointsinLIC4
-    int QUADS;       // No.ofquadrantsinLIC4
-    double DIST;     // DistanceinLIC6
-    int NPTS;        // No.ofconsecutivepts.inLIC6
-    int KPTS;        // No.ofint.pts.inLICs7,12
-    int APTS;        // No.ofint.pts.inLICs8,13
-    int BPTS;        // No.ofint.pts.inLICs8,13
-    int CPTS;        // No.ofint.pts.inLIC9
-    int DPTS;        // No.ofint.pts.inLIC9
-    int EPTS;        // No.ofint.pts.inLICs10,14
-    int FPTS;        // No.ofint.pts.inLICs10,14
-    int GPTS;        // No.ofint.pts.inLIC11
-    double LENGTH2;  // MaximumlengthinLIC12
-    double RADIUS2;  // MaximumradiusinLIC13
-    double AREA2;    // MaximumareainLIC14
+  double LENGTH1; // LengthinLICs0,7,12
+  double RADIUS1; // RadiusinLICs1,8,13
+  double EPSILON; // DeviationfromPIinLICs2,9
+  double AREA1;   // AreainLICs3,10,14
+  int QPTS;       // No.ofconsecutivepointsinLIC4
+  int QUADS;      // No.ofquadrantsinLIC4
+  double DIST;    // DistanceinLIC6
+  int NPTS;       // No.ofconsecutivepts.inLIC6
+  int KPTS;       // No.ofint.pts.inLICs7,12
+  int APTS;       // No.ofint.pts.inLICs8,13
+  int BPTS;       // No.ofint.pts.inLICs8,13
+  int CPTS;       // No.ofint.pts.inLIC9
+  int DPTS;       // No.ofint.pts.inLIC9
+  int EPTS;       // No.ofint.pts.inLICs10,14
+  int FPTS;       // No.ofint.pts.inLICs10,14
+  int GPTS;       // No.ofint.pts.inLIC11
+  double LENGTH2; // MaximumlengthinLIC12
+  double RADIUS2; // MaximumradiusinLIC13
+  double AREA2;   // MaximumareainLIC14
 } Parameters;
 
 typedef std::vector<Coordinate> Points;
@@ -64,7 +59,7 @@ static const double pi = 3.1415926535;
 
 // Global variables - defined separately in decide.cpp
 //
-extern std::vector<std::vector<Connector> > lcm;
+extern std::vector<std::vector<Connector>> lcm;
 extern std::vector<bool> puv;
 
 // Functions

--- a/decide/decide.hpp
+++ b/decide/decide.hpp
@@ -21,6 +21,14 @@ struct Coordinate {
     double distance(const Coordinate& other) const {
         return sqrt(pow(this->x - other.x, 2) + pow(this->y - other.y, 2));
     }
+
+    // Pointers are only used because `this` defaults to a pointer.
+    bool operator==(const Coordinate& c2){
+        return this->x == c2.x && this->y == c2.y;
+    }
+    bool operator!= (const Coordinate& c2){
+        return !(*this == c2);
+    }
 };
 
 /* Taken from the header file provided. Redesign as necessary.


### PR DESCRIPTION
This solves #43 by overloading the `==` and `!=` operators to work with Coordinates. Two Coordinates are equal if and only if their `x` and `y` parts are equal.