### PR TITLE
fix: Include all .cpp and .hpp files in "make format"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ DECIDE: $(objects) decide/main.o
 
 ### Formatting
 format: $(wildcard decide/*.?pp)
-	clang-format -i $< --style=file
+	clang-format -i $^ --style=file
 
 
 ### Testing


### PR DESCRIPTION
Fixes #57. The variable used in `make format` was `$<` (first prerequisite) rather than `$^` (all prerequisites).