### PR TITLE
feat: Add function to utils for checking if points can be contained by circle

### DIFF
--- a/decide/lic1.cpp
+++ b/decide/lic1.cpp
@@ -1,0 +1,89 @@
+#include <algorithm>
+#include <decide/decide.hpp>
+
+/// LIC1 is true if there exists "at least one set of three consecutive
+/// data points that cannot all be contained within or on a circle of
+/// radius RADIUS1".
+///
+/// We first check whether the points are colinear or if two points are
+/// the same; if so, we just measure the maximum length between them.
+/// If they are not all on the same line, we construct a circle out of
+/// the three points and check whether its radius is smaller than RADIUS1.
+bool lic1(Points points, Parameters params) {
+  if (points.size() < 3) {
+    return false;
+  }
+
+  for (int i = 1; i < points.size() - 1; i++) {
+    Coordinate point1 = points[i - 1];
+    Coordinate point2 = points[i];
+    Coordinate point3 = points[i + 1];
+
+    int diameter = params.RADIUS1 * 2;
+
+    int lic_condition_met = false;
+
+    // If two points are the same, check the distance between the other
+    // points (this has to be <= RADIUS1*2 (diameter))
+    // If the distance is low enough, we have met the criteria.
+    if (point1 == point2) {
+      lic_condition_met |= point1.distance(point3) <= diameter;
+    } else if (point2 == point3) {
+      lic_condition_met |= point2.distance(point1) <= diameter;
+    } else if (point1 == point3) {
+      lic_condition_met |= point1.distance(point2) <= diameter;
+    }
+
+    // If the three points are colinear, we check the longest distance
+    // between them and see if that's <= diameter
+    double slope12 = (point2.y - point1.y) / (point2.x - point1.x);
+    double slope23 = (point3.y - point2.y) / (point3.x - point2.x);
+    if (slope12 == slope23) {
+      double dist =
+          std::max(std::max(point1.distance(point2), point2.distance(point3)),
+                   point1.distance(point3));
+      lic_condition_met |= dist <= diameter;
+    }
+
+    // If we have three distinct points (that are not colinear)
+    // check if the circle formed by them has a radius less than
+    // RADIUS1.
+    // Idea for the algorithm came from the following paper by J. Riggs (2017):
+    // https://www.mathworks.com/matlabcentral/answers/uploaded_files/251674/Circle%20Calculations.pdf
+    double slope = slope12;
+    Coordinate pointA = point1;
+    Coordinate pointB = point2;
+    Coordinate pointC = point3;
+    // If points 1 and 2 have the same y, slope_perpendicular will be infinite.
+    // To avoid this, we choose points 2 and 3 instead (since we know that they
+    // are not all colinear and so 2 and 3 have to have different y values).
+    if (slope12 == 0) {
+        slope = slope23;
+        pointA = point2;
+        pointB = point3;
+        pointC = point1;
+    }
+    double midpoint_x = (pointA.x + pointB.x) / 2;
+    double midpoint_y = (pointA.y + pointB.y) / 2;
+    double slope_perpendicular = -1 / slope;
+    double perpendicular_y_intercept =
+        midpoint_y - slope_perpendicular * midpoint_x;
+    double centre_x_numerator =
+        pow(pointC.x, 2) + pow(pointC.y, 2) - pow(pointA.x, 2) -
+        pow(pointA.y, 2) +
+        2 * perpendicular_y_intercept * (pointA.y - pointC.y);
+    double centre_x_denominator =
+        2 * (pointC.x - pointA.x + slope_perpendicular * (pointC.y - pointA.y));
+    double centre_x = centre_x_numerator / centre_x_denominator;
+    double centre_y =
+        slope_perpendicular * centre_x + perpendicular_y_intercept;
+
+    double radius = pointA.distance({centre_x, centre_y});
+    lic_condition_met |= radius <= params.RADIUS1;
+
+    if (lic_condition_met)
+      return true;
+  }
+
+  return false;
+}

--- a/decide/lic1.cpp
+++ b/decide/lic1.cpp
@@ -58,10 +58,10 @@ bool lic1(Points points, Parameters params) {
     // To avoid this, we choose points 2 and 3 instead (since we know that they
     // are not all colinear and so 2 and 3 have to have different y values).
     if (slope12 == 0) {
-        slope = slope23;
-        pointA = point2;
-        pointB = point3;
-        pointC = point1;
+      slope = slope23;
+      pointA = point2;
+      pointB = point3;
+      pointC = point1;
     }
     double midpoint_x = (pointA.x + pointB.x) / 2;
     double midpoint_y = (pointA.y + pointB.y) / 2;

--- a/decide/lic1.test.cpp
+++ b/decide/lic1.test.cpp
@@ -1,0 +1,58 @@
+#include <cassert>
+#include <cstdlib>
+#include <decide/decide.hpp>
+#include <decide/lics.hpp>
+
+// Three points that fit inside the circle (two have the same y coord)
+void test_true_instance_same_y() {
+  Points points{Coordinate{1, 3}, Coordinate{3, 3}, Coordinate{2, 1}};
+  Parameters parameters{.RADIUS1 = 2};
+  assert(lic1(points, parameters));
+}
+
+// Three points that fit inside the circle (two have the same x coord)
+// Padded with other coordinates.
+void test_true_instance_same_x() {
+  Points points{Coordinate{67, 43}, Coordinate{23, 23}, Coordinate{2, 0.5},
+                Coordinate{2, 4}, Coordinate{4, 2}};
+  Parameters parameters{.RADIUS1 = 2};
+  assert(lic1(points, parameters));
+}
+
+// No distance between the three middle points is greater than the diameter,
+// but they are too far apart to fit in the circle. Padded with other
+// coordinates to ensure that it loops through the vector properly.
+void test_false_instance() {
+  Points points{Coordinate{67, 43}, Coordinate{4, 2}, Coordinate{0, 2},
+                Coordinate{2, 5}, Coordinate{23, 23}};
+  Parameters parameters{.RADIUS1 = 2};
+  assert(!lic1(points, parameters));
+}
+
+// We need at least three points to meet the condition
+void test_too_small_instance() {
+  Points points{Coordinate{1, 1}, Coordinate{2, 2}};
+  Parameters parameters{.RADIUS1 = 3};
+  assert(!lic1(points, parameters));
+}
+
+void test_colinear_true() {
+  Points points{Coordinate{1, 1}, Coordinate{2, 2}, Coordinate{3, 3}};
+  Parameters parameters{.RADIUS1 = 2};
+  assert(lic1(points, parameters));
+}
+
+void test_colinear_false() {
+  Points points{Coordinate{0, 0}, Coordinate{2, 2}, Coordinate{4, 4}};
+  Parameters parameters{.RADIUS1 = 2};
+  assert(!lic1(points, parameters));
+}
+
+int main() {
+  test_true_instance_same_x();
+  test_true_instance_same_y();
+  test_false_instance();
+  test_too_small_instance();
+  test_colinear_false();
+  test_colinear_true();
+}

--- a/decide/lics.hpp
+++ b/decide/lics.hpp
@@ -5,5 +5,6 @@
 
 // Functions
 bool lic0(Points points, Parameters parameters);
+bool lic1(Points points, Parameters parameters);
 
 #endif

--- a/decide/utils.hpp
+++ b/decide/utils.hpp
@@ -1,8 +1,72 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#include <decide.hpp>
+#include <decide/decide.hpp>
 
 // Add util functions here
+bool contained_in_circle(Coordinate point1, Coordinate point2,
+                         Coordinate point3, double RADIUS1) {
+  int diameter = RADIUS1 * 2;
+  int lic_condition_met = false;
+
+  // If two points are the same, check the distance between the other
+  // points (this has to be <= RADIUS1*2 (diameter))
+  // If the distance is low enough, we have met the criteria.
+  if (point1 == point2) {
+    lic_condition_met |= point1.distance(point3) <= diameter;
+  } else if (point2 == point3) {
+    lic_condition_met |= point2.distance(point1) <= diameter;
+  } else if (point1 == point3) {
+    lic_condition_met |= point1.distance(point2) <= diameter;
+  }
+
+  // If the three points are colinear, we check the longest distance
+  // between them and see if that's <= diameter
+  double slope12 = (point2.y - point1.y) / (point2.x - point1.x);
+  double slope23 = (point3.y - point2.y) / (point3.x - point2.x);
+  if (slope12 == slope23) {
+    double dist =
+        std::max(std::max(point1.distance(point2), point2.distance(point3)),
+                 point1.distance(point3));
+    lic_condition_met |= dist <= diameter;
+  }
+
+  // If we have three distinct points (that are not colinear)
+  // check if the circle formed by them has a radius less than
+  // RADIUS1.
+  // Idea for the algorithm came from the following paper by J. Riggs (2017):
+  // https://www.mathworks.com/matlabcentral/answers/uploaded_files/251674/Circle%20Calculations.pdf
+  double slope = slope12;
+  Coordinate pointA = point1;
+  Coordinate pointB = point2;
+  Coordinate pointC = point3;
+  // If points 1 and 2 have the same y, slope_perpendicular will be infinite.
+  // To avoid this, we choose points 2 and 3 instead (since we know that they
+  // are not all colinear and so 2 and 3 have to have different y values).
+  if (slope12 == 0) {
+    slope = slope23;
+    pointA = point2;
+    pointB = point3;
+    pointC = point1;
+  }
+
+  double midpoint_x = (pointA.x + pointB.x) / 2;
+  double midpoint_y = (pointA.y + pointB.y) / 2;
+  double slope_perpendicular = -1 / slope;
+  double perpendicular_y_intercept =
+      midpoint_y - slope_perpendicular * midpoint_x;
+  double centre_x_numerator =
+      pow(pointC.x, 2) + pow(pointC.y, 2) - pow(pointA.x, 2) -
+      pow(pointA.y, 2) + 2 * perpendicular_y_intercept * (pointA.y - pointC.y);
+  double centre_x_denominator =
+      2 * (pointC.x - pointA.x + slope_perpendicular * (pointC.y - pointA.y));
+  double centre_x = centre_x_numerator / centre_x_denominator;
+  double centre_y = slope_perpendicular * centre_x + perpendicular_y_intercept;
+
+  double radius = pointA.distance({centre_x, centre_y});
+  lic_condition_met |= radius <= RADIUS1;
+
+  return lic_condition_met;
+}
 
 #endif


### PR DESCRIPTION
This adds a function in `utils.hpp` that checks whether three points can be contained within a circle of a given radius. Will be used in the implementation of at least two LIC functions (#2 and #9).