### PR TITLE
feat: add calculateCMV function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ format: $(wildcard decide/*.?pp)
 
 
 ### Testing
+#Special case for decide.test as it uses all LICs
+decide/decide.test: $(objects) decide/decide.test.cpp
+	$(CXX) -o $@ $^ $(CXXFLAGS)
+
 %.test: %.test.cpp %.cpp decide/utils.cpp
 	$(CXX) -o $@ $^ $(CXXFLAGS)
 

--- a/decide/decide.cpp
+++ b/decide/decide.cpp
@@ -3,6 +3,27 @@
 #include <decide/lics.hpp>
 #include <iostream>
 
+CMV calculateCMV(Points points, Parameters parameters) {
+    CMV cmv(15);
+    cmv[0] = lic0(points, parameters);
+    cmv[1] = lic1(points, parameters);
+    cmv[2] = lic2(points, parameters);
+    cmv[3] = lic3(points, parameters);
+    cmv[4] = lic4(points, parameters);
+    cmv[5] = lic5(points, parameters);
+    cmv[6] = lic6(points, parameters);
+    cmv[7] = lic7(points, parameters);
+    cmv[8] = lic8(points, parameters);
+    cmv[9] = lic9(points, parameters);
+    cmv[10] = lic10(points, parameters);
+    cmv[11] = lic11(points, parameters);
+    cmv[12] = lic12(points, parameters);
+    cmv[13] = lic13(points, parameters);
+    cmv[14] = lic14(points, parameters);
+
+    return cmv;
+}
+
 PUM calculatePUM(CMV cmv, LCM lcm) {
   int n = cmv.size();
 

--- a/decide/decide.cpp
+++ b/decide/decide.cpp
@@ -3,25 +3,27 @@
 #include <decide/lics.hpp>
 #include <iostream>
 
+/* A vector with the return values of all the LIC functions
+ */
 CMV calculateCMV(Points points, Parameters parameters) {
-    CMV cmv(15);
-    cmv[0] = lic0(points, parameters);
-    cmv[1] = lic1(points, parameters);
-    cmv[2] = lic2(points, parameters);
-    cmv[3] = lic3(points, parameters);
-    cmv[4] = lic4(points, parameters);
-    cmv[5] = lic5(points, parameters);
-    cmv[6] = lic6(points, parameters);
-    cmv[7] = lic7(points, parameters);
-    cmv[8] = lic8(points, parameters);
-    cmv[9] = lic9(points, parameters);
-    cmv[10] = lic10(points, parameters);
-    cmv[11] = lic11(points, parameters);
-    cmv[12] = lic12(points, parameters);
-    cmv[13] = lic13(points, parameters);
-    cmv[14] = lic14(points, parameters);
+  CMV cmv(15);
+  cmv[0] = lic0(points, parameters);
+  cmv[1] = lic1(points, parameters);
+  cmv[2] = lic2(points, parameters);
+  cmv[3] = lic3(points, parameters);
+  cmv[4] = lic4(points, parameters);
+  cmv[5] = lic5(points, parameters);
+  cmv[6] = lic6(points, parameters);
+  cmv[7] = lic7(points, parameters);
+  cmv[8] = lic8(points, parameters);
+  cmv[9] = lic9(points, parameters);
+  cmv[10] = lic10(points, parameters);
+  cmv[11] = lic11(points, parameters);
+  cmv[12] = lic12(points, parameters);
+  cmv[13] = lic13(points, parameters);
+  cmv[14] = lic14(points, parameters);
 
-    return cmv;
+  return cmv;
 }
 
 PUM calculatePUM(CMV cmv, LCM lcm) {

--- a/decide/decide.hpp
+++ b/decide/decide.hpp
@@ -65,6 +65,7 @@ static const double pi = 3.1415926535;
 
 // Functions
 void decide(FUV &fuv);
+CMV calculateCMV(Points points, Parameters parameters);
 PUM calculatePUM(CMV cmv, LCM lcm);
 FUV calculateFUV(PUM &pum, PUV &puv);
 

--- a/decide/decide.test.cpp
+++ b/decide/decide.test.cpp
@@ -144,6 +144,7 @@ void test_decide() {
 }
 
 int main() {
+  test_cmv();
   test_pum();
   test_fuv();
   test_decide();

--- a/decide/decide.test.cpp
+++ b/decide/decide.test.cpp
@@ -17,8 +17,36 @@ private:
   std::streambuf *old;
 };
 
+CMV calculateCMV(Points points, Parameters parameters);
 PUM calculatePUM(CMV cmv, LCM lcm);
 FUV calculateFUV(PUM &pum, PUV &puv);
+
+void test_cmv() {
+  Points points{Coordinate{0, 0},     Coordinate{2, 2},  Coordinate{3, 2},
+                Coordinate{100, 100}, Coordinate{4, 4},  Coordinate{3245, 232},
+                Coordinate{529, 234}, Coordinate{50, 1}, Coordinate{12, 12}};
+  Parameters parameters{.LENGTH1 = 5, .RADIUS1 = 49, .EPSILON = 3, .AREA1 = 50,
+      .QPTS = 2, .QUADS = 2, .DIST = 6, .NPTS = 3, .KPTS = 1, .APTS = 2, .BPTS = 3,
+      .CPTS = 1, .DPTS = 1, .EPTS = 1, .FPTS = 1, .GPTS = 2, .LENGTH2 = 8,
+      .RADIUS2 = 7.5, .AREA2 = 20};
+  CMV cmv = calculateCMV(points, parameters);
+
+  assert(cmv[0] = lic0(points, parameters));
+  assert(cmv[1] = lic1(points, parameters));
+  assert(cmv[2] = lic2(points, parameters));
+  assert(cmv[3] = lic3(points, parameters));
+  assert(cmv[4] = lic4(points, parameters));
+  assert(cmv[5] = lic5(points, parameters));
+  assert(cmv[6] = lic6(points, parameters));
+  assert(cmv[7] = lic7(points, parameters));
+  assert(cmv[8] = lic8(points, parameters));
+  assert(cmv[9] = lic9(points, parameters));
+  assert(cmv[10] = lic10(points, parameters));
+  assert(cmv[11] = lic11(points, parameters));
+  assert(cmv[12] = lic12(points, parameters));
+  assert(cmv[13] = lic13(points, parameters));
+  assert(cmv[14] = lic14(points, parameters));
+}
 
 void assert_pum_equal(PUM &p1, PUM &p2) {
   int n = p1.size();

--- a/decide/decide.test.cpp
+++ b/decide/decide.test.cpp
@@ -50,21 +50,21 @@ void test_cmv() {
                         .AREA2 = 20};
   CMV cmv = calculateCMV(points, parameters);
 
-  assert(cmv[0] = lic0(points, parameters));
-  assert(cmv[1] = lic1(points, parameters));
-  assert(cmv[2] = lic2(points, parameters));
-  assert(cmv[3] = lic3(points, parameters));
-  assert(cmv[4] = lic4(points, parameters));
-  assert(cmv[5] = lic5(points, parameters));
-  assert(cmv[6] = lic6(points, parameters));
-  assert(cmv[7] = lic7(points, parameters));
-  assert(cmv[8] = lic8(points, parameters));
-  assert(cmv[9] = lic9(points, parameters));
-  assert(cmv[10] = lic10(points, parameters));
-  assert(cmv[11] = lic11(points, parameters));
-  assert(cmv[12] = lic12(points, parameters));
-  assert(cmv[13] = lic13(points, parameters));
-  assert(cmv[14] = lic14(points, parameters));
+  assert(cmv[0] == lic0(points, parameters));
+  assert(cmv[1] == lic1(points, parameters));
+  assert(cmv[2] == lic2(points, parameters));
+  assert(cmv[3] == lic3(points, parameters));
+  assert(cmv[4] == lic4(points, parameters));
+  assert(cmv[5] == lic5(points, parameters));
+  assert(cmv[6] == lic6(points, parameters));
+  assert(cmv[7] == lic7(points, parameters));
+  assert(cmv[8] == lic8(points, parameters));
+  assert(cmv[9] == lic9(points, parameters));
+  assert(cmv[10] == lic10(points, parameters));
+  assert(cmv[11] == lic11(points, parameters));
+  assert(cmv[12] == lic12(points, parameters));
+  assert(cmv[13] == lic13(points, parameters));
+  assert(cmv[14] == lic14(points, parameters));
 }
 
 void assert_pum_equal(PUM &p1, PUM &p2) {

--- a/decide/decide.test.cpp
+++ b/decide/decide.test.cpp
@@ -21,14 +21,33 @@ CMV calculateCMV(Points points, Parameters parameters);
 PUM calculatePUM(CMV cmv, LCM lcm);
 FUV calculateFUV(PUM &pum, PUV &puv);
 
+/* This tests that every element in CMV is equal to the lic it should be equal
+ * to This test should be enough if we assume that the LIC functions themselves
+ * are correct, which we can do because they are tested separately
+ */
 void test_cmv() {
   Points points{Coordinate{0, 0},     Coordinate{2, 2},  Coordinate{3, 2},
                 Coordinate{100, 100}, Coordinate{4, 4},  Coordinate{3245, 232},
                 Coordinate{529, 234}, Coordinate{50, 1}, Coordinate{12, 12}};
-  Parameters parameters{.LENGTH1 = 5, .RADIUS1 = 49, .EPSILON = 3, .AREA1 = 50,
-      .QPTS = 2, .QUADS = 2, .DIST = 6, .NPTS = 3, .KPTS = 1, .APTS = 2, .BPTS = 3,
-      .CPTS = 1, .DPTS = 1, .EPTS = 1, .FPTS = 1, .GPTS = 2, .LENGTH2 = 8,
-      .RADIUS2 = 7.5, .AREA2 = 20};
+  Parameters parameters{.LENGTH1 = 5,
+                        .RADIUS1 = 49,
+                        .EPSILON = 3,
+                        .AREA1 = 50,
+                        .QPTS = 2,
+                        .QUADS = 2,
+                        .DIST = 6,
+                        .NPTS = 3,
+                        .KPTS = 1,
+                        .APTS = 2,
+                        .BPTS = 3,
+                        .CPTS = 1,
+                        .DPTS = 1,
+                        .EPTS = 1,
+                        .FPTS = 1,
+                        .GPTS = 2,
+                        .LENGTH2 = 8,
+                        .RADIUS2 = 7.5,
+                        .AREA2 = 20};
   CMV cmv = calculateCMV(points, parameters);
 
   assert(cmv[0] = lic0(points, parameters));

--- a/decide/main.cpp
+++ b/decide/main.cpp
@@ -1,10 +1,13 @@
 #include <decide/decide.hpp>
 
 int main() {
-  CMV cmv;
   LCM lcm;
   PUV puv;
-  
+
+  Points points;
+  Parameters parameters;
+
+  CMV cmv = calculateCMV(points, parameters);
   PUM pum = calculatePUM(cmv, lcm);
   FUV fuv = calculateFUV(pum, puv);
 


### PR DESCRIPTION
resolves #108

The CMV is based on the LICs and is needed for calculating the PUM