### PR TITLE
fix: use only positive angles, add test for this

### DIFF
--- a/decide/lic6.test.cpp
+++ b/decide/lic6.test.cpp
@@ -13,7 +13,7 @@ void test_distance_from_line() {
   auto start = Coordinate(100, -73.75);
   auto end = Coordinate(-100, 76.25);
   double result = distanceFromLine(point, start, end);
-  assert(abs(result - 9.0 / 5.0) < 0.0001);
+  assert(std::abs(result - 9.0 / 5.0) < 0.0001);
 }
 
 // The point is closest to another point,
@@ -23,7 +23,7 @@ void test_distance_from_point() {
   auto start = Coordinate(1, 1);
   auto end = Coordinate(0, 0);
   double result = distanceFromLine(point, start, end);
-  assert(abs(result - sqrt(2.0)) < 0.0001);
+  assert(std::abs(result - sqrt(2.0)) < 0.0001);
 }
 
 // The coordinate (5,11) will be >10 above the line

--- a/decide/utils.cpp
+++ b/decide/utils.cpp
@@ -1,5 +1,7 @@
+#include <cmath>
 #include <decide/utils.hpp>
 
+/* The first argument is the vertex of the angle */
 double angle_between_points(Coordinate A, Coordinate B, Coordinate C) {
   if (A.x == B.x && A.y == B.y)
     return 0.0;
@@ -12,7 +14,7 @@ double angle_between_points(Coordinate A, Coordinate B, Coordinate C) {
 
   double a = atan2(B.y - A.y, B.x - A.x);
   double b = atan2(C.y - A.y, C.x - A.x);
-  return b - a;
+  return abs(b - a);
 }
 
 double triangleArea(Coordinate p1, Coordinate p2, Coordinate p3) {

--- a/decide/utils.cpp
+++ b/decide/utils.cpp
@@ -14,13 +14,13 @@ double angle_between_points(Coordinate A, Coordinate B, Coordinate C) {
 
   double a = atan2(B.y - A.y, B.x - A.x);
   double b = atan2(C.y - A.y, C.x - A.x);
-  return abs(b - a);
+  return std::abs(b - a);
 }
 
 double triangleArea(Coordinate p1, Coordinate p2, Coordinate p3) {
   // See https://www.omnicalculator.com/math/area-triangle-coordinates
-  return (1.0 / 2.0) * abs(p1.x * (p2.y - p3.y) + p2.x * (p3.y - p1.y) +
-                           p3.x * (p1.y - p2.y));
+  return (1.0 / 2.0) * std::abs(p1.x * (p2.y - p3.y) + p2.x * (p3.y - p1.y) +
+                                p3.x * (p1.y - p2.y));
 }
 
 bool contained_in_circle(Coordinate point1, Coordinate point2,

--- a/decide/utils.hpp
+++ b/decide/utils.hpp
@@ -9,6 +9,7 @@
 
 // Given three points returns the angle formed by the triangle a --> b --> c
 // expressed in radians.
+// The first argument is the vertex of the angle
 double angle_between_points(Coordinate A, Coordinate B, Coordinate C);
 
 // Calculates the area of a triangle

--- a/decide/utils.test.cpp
+++ b/decide/utils.test.cpp
@@ -8,12 +8,27 @@ void test_angle_90_degree() {
   assert((angle - pi / 4.0) < 1e-10);
 }
 
+void test_angle_between_0_2pi() {
+  double angle1 = angle_between_points(Coordinate(0, 1), Coordinate(0, 0),
+                                       Coordinate(1, 0));
+  double angle2 = angle_between_points(Coordinate(1, 1), Coordinate(0, 0),
+                                       Coordinate(1, 0));
+  double angle3 = angle_between_points(Coordinate(-1, -1), Coordinate(0, 0),
+                                       Coordinate(1, 0));
+
+  assert((0 <= angle1) && (angle1 < 2 * pi));
+  assert((0 <= angle2) && (angle2 < 2 * pi));
+  assert((0 <= angle3) && (angle3 < 2 * pi));
+}
+
 void test_triangle_area() {
-  double a = triangleArea(Coordinate(1, 2), Coordinate(-1, 1), Coordinate(0, 5));
+  double a =
+      triangleArea(Coordinate(1, 2), Coordinate(-1, 1), Coordinate(0, 5));
   assert(a == 3.5);
 }
 
-int main() { 
+int main() {
   test_triangle_area();
   test_angle_90_degree();
+  test_angle_between_0_2pi();
 }

--- a/decide/utils.test.cpp
+++ b/decide/utils.test.cpp
@@ -4,21 +4,29 @@
 
 void test_angle_90_degree() {
   double angle = angle_between_points(Coordinate(0, 1), Coordinate(0, 0),
-                                      Coordinate(1, 0));
-  assert((angle - pi / 4.0) < 1e-10);
+                                      Coordinate(1, 1));
+  assert((angle - pi / 2.0) < 1e-10);
+  assert((angle - pi / 2.0) > -1e-10);
 }
 
-void test_angle_between_0_2pi() {
+/* these should all be 45 degrees, the lines test different orders and rotations
+ * of that same angle */
+void test_angles_45_degree() {
   double angle1 = angle_between_points(Coordinate(0, 1), Coordinate(0, 0),
                                        Coordinate(1, 0));
   double angle2 = angle_between_points(Coordinate(1, 1), Coordinate(0, 0),
                                        Coordinate(1, 0));
-  double angle3 = angle_between_points(Coordinate(-1, -1), Coordinate(0, 0),
-                                       Coordinate(1, 0));
+  double angle3 = angle_between_points(Coordinate(-1, -1), Coordinate(-1, 0),
+                                       Coordinate(0, 0));
 
-  assert((0 <= angle1) && (angle1 < 2 * pi));
-  assert((0 <= angle2) && (angle2 < 2 * pi));
-  assert((0 <= angle3) && (angle3 < 2 * pi));
+  assert((angle1 - pi / 4.0) < 1e-10);
+  assert((angle1 - pi / 4.0) > -1e-10);
+
+  assert((angle2 - pi / 4.0) < 1e-10);
+  assert((angle2 - pi / 4.0) > -1e-10);
+
+  assert((angle3 - pi / 4.0) < 1e-10);
+  assert((angle3 - pi / 4.0) > -1e-10);
 }
 
 void test_triangle_area() {
@@ -30,5 +38,5 @@ void test_triangle_area() {
 int main() {
   test_triangle_area();
   test_angle_90_degree();
-  test_angle_between_0_2pi();
+  test_angles_45_degree();
 }


### PR DESCRIPTION
resolves #120

the angle function in utils has been changed to return the absolute value of its result, and a test has been added, and another test fixed, to make sure of this. All abs() usages now return double instead of int.